### PR TITLE
bugfix: Updated version of download-artifact in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Download CSS artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: css-build
           path: static/css/


### PR DESCRIPTION
- Changed version of `download-artifact` to `v4` from `v3` in `cd.yml`