### PR TITLE
bugfix: Permissions on CD and Release workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,6 +34,11 @@ jobs:
   
   build-docker-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     needs: [compile-tailwind]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
 
   build-and-push-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     needs: [compile-tailwind]
     steps:
       - name: Checkout


### PR DESCRIPTION
Added permissions block to workflows where we are publishing image to GitHub container registry.